### PR TITLE
Feature/27 timeline display errors

### DIFF
--- a/src/components/atoms/TimelineLink/index.js
+++ b/src/components/atoms/TimelineLink/index.js
@@ -1,0 +1,23 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import {Link} from 'react-router-dom'
+
+export default function TimelineLink({id, label}) {
+	const timelineStyle = {
+		fontSize: '1.4em',
+		textDecoration: 'none',
+	}
+
+	return (
+		<span>
+			<Link style={timelineStyle} to={`/timelines/timeline${id}`}>
+				{label || id}
+			</Link>
+		</span>
+	);
+}
+
+TimelineLink.propTypes = {
+	id: PropTypes.string.isRequired,
+	label: PropTypes.string,
+}

--- a/src/components/atoms/TimelineLinks/index.js
+++ b/src/components/atoms/TimelineLinks/index.js
@@ -2,15 +2,15 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import TimelineLink from '../TimelineLink'
 
-export default function TimelineLinks({id, timelines}) {
+export default function TimelineLinks({groupId, timelines}) {
   const hasTimelines = Array.isArray(timelines) && timelines.length
 
   return (
     <>
       {hasTimelines && (
         <div>
-          {timelines.map(({id: timelineId, label}) => (
-            <TimelineLink id={id} key={`${id}${timelineId}`} label={label} />
+          {timelines.map(({id, label}) => (
+            <TimelineLink id={id} key={`${groupId}-${id}`} label={label} />
           ))}
         </div>
       )}
@@ -19,7 +19,7 @@ export default function TimelineLinks({id, timelines}) {
 }
 
 TimelineLinks.propTypes = {
-  id: PropTypes.string,
+  groupId: PropTypes.string,
   timelines: PropTypes.arrayOf(
     PropTypes.shape({
       id: PropTypes.string,

--- a/src/components/atoms/TimelineLinks/index.js
+++ b/src/components/atoms/TimelineLinks/index.js
@@ -1,0 +1,29 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import TimelineLink from '../TimelineLink'
+
+export default function TimelineLinks({id, timelines}) {
+  const hasTimelines = Array.isArray(timelines) && timelines.length
+
+  return (
+    <>
+      {hasTimelines && (
+        <div>
+          {timelines.map(({id: timelineId, label}) => (
+            <TimelineLink id={id} key={`${id}${timelineId}`} label={label} />
+          ))}
+        </div>
+      )}
+    </>
+  )
+}
+
+TimelineLinks.propTypes = {
+  id: PropTypes.string,
+  timelines: PropTypes.arrayOf(
+    PropTypes.shape({
+      id: PropTypes.string,
+      label: PropTypes.string,
+    }),
+  ),
+}

--- a/src/components/organisms/All.js
+++ b/src/components/organisms/All.js
@@ -22,7 +22,7 @@ const All = ({timelinePosts, uid}) => {
       {isLoaded === true &&
         timelinePosts.length >= 1 &&
         timelinePosts.map((data, key) => {
-          const {date, id, imageURL, slug, timeline, title} = data
+          const {date, id, imageURL, slug, timelines, title} = data
 
           return (
             <TimelinePost
@@ -32,7 +32,7 @@ const All = ({timelinePosts, uid}) => {
               key={key}
               slug={slug}
               style={loadingStyle}
-              timeline={timeline}
+              timelines={timelines}
               title={title}
             />
           )

--- a/src/components/organisms/Single.js
+++ b/src/components/organisms/Single.js
@@ -4,7 +4,7 @@ import TimelinePost from '../organisms/TimelinePost'
 import PostControls from '../molecules/PostControls'
 
 const Single = props => {
-  const {date, id, imageURL, slug, timeline, title} = props
+  const {date, id, imageURL, slug, timelines, title} = props
 
   return (
     <div>
@@ -14,7 +14,7 @@ const Single = props => {
         id={id}
         imageURL={imageURL}
         slug={slug}
-        timeline={timeline}
+        timelines={timelines}
         title={title}
       />
     </div>
@@ -26,7 +26,7 @@ Single.propTypes = {
   id: PropTypes.string,
   imageURL: PropTypes.string,
   slug: PropTypes.string,
-  timeline: PropTypes.object,
+  timelines: PropTypes.object,
   title: PropTypes.string,
 }
 

--- a/src/components/organisms/Timeline.js
+++ b/src/components/organisms/Timeline.js
@@ -26,7 +26,7 @@ const Timeline = ({timelinePosts, timeline, uid}) => {
   return (
     <>
       {postsInTimeline.map((data, key) => {
-        const {date, id, imageURL, slug, timeline, title} = data
+        const {date, id, imageURL, slug, timelines, title} = data
 
         return (
           <TimelinePost
@@ -36,7 +36,7 @@ const Timeline = ({timelinePosts, timeline, uid}) => {
             key={key}
             slug={slug}
             style={loadingStyle}
-            timeline={timeline}
+            timelines={timelines}
             title={title}
           />
         )
@@ -47,7 +47,7 @@ const Timeline = ({timelinePosts, timeline, uid}) => {
 
 Timeline.propTypes = {
   timelinePosts: PropTypes.array,
-  timeline: PropTypes.object,
+  timelines: PropTypes.object,
   uid: PropTypes.string,
 }
 

--- a/src/components/organisms/TimelinePost.js
+++ b/src/components/organisms/TimelinePost.js
@@ -1,12 +1,11 @@
 import React, {useState, useEffect} from 'react'
+import PropTypes from 'prop-types'
 import {Link} from 'react-router-dom'
 import firebase from '../../firebase'
 import {format} from 'date-fns'
 import TimelineLinks from '../atoms/TimelineLinks'
 
-// eslint-disable-next-line react/prop-types
-const TimelinePost = ({date, id, imageURL, title, timelines}) => {
-  // eslint-disable-next-line no-unused-vars
+const TimelinePost = ({date, id, imageURL, timelines, title}) => {
   const [timelineData, setTimelineData] = useState([])
 
   const style = {
@@ -47,6 +46,14 @@ const TimelinePost = ({date, id, imageURL, title, timelines}) => {
       {imageURL && <img src={imageURL} alt={title} />}
     </article>
   )
+}
+
+TimelinePost.propTypes = {
+  date: PropTypes.string,
+  id: PropTypes.string,
+  imageURL: PropTypes.string,
+  timelines: PropTypes.object,
+  title: PropTypes.string,
 }
 
 export default TimelinePost

--- a/src/components/organisms/TimelinePost.js
+++ b/src/components/organisms/TimelinePost.js
@@ -2,6 +2,7 @@ import React, {useState, useEffect} from 'react'
 import {Link} from 'react-router-dom'
 import firebase from '../../firebase'
 import {format} from 'date-fns'
+import TimelineLink from '../atoms/TimelineLink'
 
 // eslint-disable-next-line react/prop-types
 const TimelinePost = ({date, id, imageURL, title, timelines}) => {
@@ -10,11 +11,6 @@ const TimelinePost = ({date, id, imageURL, title, timelines}) => {
 
   const style = {
     padding: '.2em',
-  }
-
-  const timelineStyle = {
-    fontSize: '1.4em',
-    textDecoration: 'none',
   }
 
   useEffect(() => {
@@ -48,11 +44,11 @@ const TimelinePost = ({date, id, imageURL, title, timelines}) => {
         {timelineData &&
           timelineData.length &&
           timelineData.map(({id: timelineId, label}) => (
-            <span key={`${id}${timelineId}`}>
-              <Link style={timelineStyle} to={`/timelines/timeline${id}`}>
-                {label}
-              </Link>
-            </span>
+            <TimelineLink
+              id={id}
+              key={`${id}${timelineId}`}
+              label={label}
+            />
           ))}
         <p>{format(new Date(date), 'iiii, MMMM d, RRRR hh:mm a')}</p>
       </div>

--- a/src/components/organisms/TimelinePost.js
+++ b/src/components/organisms/TimelinePost.js
@@ -40,7 +40,7 @@ const TimelinePost = ({date, id, imageURL, timelines, title}) => {
         <h1>
           <Link to={`/posts/post${id}`}>{title || 'undefined'}</Link>
         </h1>
-        <TimelineLinks id={id} timelines={timelineData} />
+        <TimelineLinks groupId={id} timelines={timelineData} />
         <p>{format(new Date(date), 'iiii, MMMM d, RRRR hh:mm a')}</p>
       </div>
       {imageURL && <img src={imageURL} alt={title} />}

--- a/src/components/organisms/TimelinePost.js
+++ b/src/components/organisms/TimelinePost.js
@@ -2,7 +2,7 @@ import React, {useState, useEffect} from 'react'
 import {Link} from 'react-router-dom'
 import firebase from '../../firebase'
 import {format} from 'date-fns'
-import TimelineLink from '../atoms/TimelineLink'
+import TimelineLinks from '../atoms/TimelineLinks'
 
 // eslint-disable-next-line react/prop-types
 const TimelinePost = ({date, id, imageURL, title, timelines}) => {
@@ -41,15 +41,7 @@ const TimelinePost = ({date, id, imageURL, title, timelines}) => {
         <h1>
           <Link to={`/posts/post${id}`}>{title || 'undefined'}</Link>
         </h1>
-        {timelineData &&
-          timelineData.length &&
-          timelineData.map(({id: timelineId, label}) => (
-            <TimelineLink
-              id={id}
-              key={`${id}${timelineId}`}
-              label={label}
-            />
-          ))}
+        <TimelineLinks id={id} timelines={timelineData} />
         <p>{format(new Date(date), 'iiii, MMMM d, RRRR hh:mm a')}</p>
       </div>
       {imageURL && <img src={imageURL} alt={title} />}


### PR DESCRIPTION
This update refactors singular timeline links for the new data structure mentioned in #27. By converting `timeline` to `timelines` this sets up the data to retrieve an Array of timelines. As a result components needed to be updated and created to handle this change.

Updates:
- Refactor `getTimelineData()` to handle the new data.
- Create `TimelineLinks` component for mapping through data retreived from `getTimelineData()` and rendering `TimelineLink`
- Create `TimelineLink` for handling each link element
- Replace `timeline` keys used throughout project with `timelines` key

This example shows timelines associated with each post as a result of the new updates.
<img width="889" alt="Screen Shot 2021-06-03 at 8 45 23 PM" src="https://user-images.githubusercontent.com/25035900/120729257-ae24d300-c4ac-11eb-8a7f-c5d2f514694f.png">
