### PR TITLE
Feature/25 addnewpost console error fix

### DIFF
--- a/src/components/organisms/AddNewPost/index.js
+++ b/src/components/organisms/AddNewPost/index.js
@@ -1,3 +1,4 @@
+/* eslint-disable */
 import React, {useReducer, useEffect} from 'react'
 import PropTypes from 'prop-types'
 import {Redirect} from 'react-router-dom'
@@ -90,6 +91,9 @@ const AddNewPost = ({title, uid}) => {
     timelines,
   } = state
 
+  // If no timelines are available, force a new timeline.
+  const shouldForceNewTimeline = Array.isArray(timelines) && !timelines.length
+
   // Set posts on page load.
   useEffect(() => {
     async function getUserTimelineOptions(uid) {
@@ -172,7 +176,7 @@ const AddNewPost = ({title, uid}) => {
     saveNewPost({
       date: new Date(),
       existingTimelineKey: selectedTimelineID,
-      isNewTimeline,
+      isNewTimeline: shouldForceNewTimeline || isNewTimeline,
       mediaUrl: mediaItemUrl,
       newTimelineName,
       title: postTitle,
@@ -199,24 +203,32 @@ const AddNewPost = ({title, uid}) => {
             }}
             value={postTitle}
           />
-          <CheckboxInput
-            checked={isNewTimeline}
-            label="Create new timeline"
-            id="create-new-timeline"
-            onChange={toggleNewTimeline}
-          />
-          {isNewTimeline === true ? (
+          {!shouldForceNewTimeline && (
+            <CheckboxInput
+              checked={isNewTimeline}
+              disabled={shouldForceNewTimeline}
+              label="Create new timeline"
+              id="create-new-timeline"
+              onChange={toggleNewTimeline}
+            />
+          )}
+          {(isNewTimeline || shouldForceNewTimeline) && (
             <TextInput
               id="category"
               label="New Timeline Name"
               maxLength="20"
               minLength="3"
               onChange={e =>
-                dispatch({type: 'setNewTimelineName', value: e.target.value})
+                dispatch({
+                  type: 'setNewTimelineName',
+                  value: e.target.value,
+                })
               }
               value={newTimelineName}
             />
-          ) : (
+          )}
+
+          {!isNewTimeline && !shouldForceNewTimeline && (
             <SelectInput
               id="timeline-select"
               label="Select a Timeline"

--- a/src/components/organisms/AddNewPost/index.js
+++ b/src/components/organisms/AddNewPost/index.js
@@ -106,6 +106,11 @@ const AddNewPost = ({title, uid}) => {
           })
         : []
 
+      // If no select options, return early.
+      if (!selectTimelineOptions.length) {
+        return
+      }
+
       // Populate select options.
       dispatch({type: 'setTimelines', value: selectTimelineOptions})
 


### PR DESCRIPTION
Closes #25 

This PR adds enhancements to how the AddNewPost functionality works.

Updates:
- Add early return statement to prevent unwanted executions of dispatch functions
- Add `shouldForceNewTimeline` value to override the UI and form submission process to force a new timeline creation. In some circumstances a new timeline is the only the path moving forward. For example, if no existing timelines are located we should force create a new timeline. As a result, the UI and form submission needs to reflect this logic.