### PR TITLE
Fix image border radius

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -39,13 +39,13 @@ main {
 
 article {
   background-color: inherit;
-  border-radius: .4em;
   margin: 0 auto 2.4em auto;
   max-width: 800px;
   overflow: hidden;
 }
 
 article img {
+  border-radius: 0.4em;
   display: block;
   max-width: 100%;
   width: 100%;


### PR DESCRIPTION
Fix image border radius by moving the styling rule directly to the image

After updates:
<img width="540" alt="Screen Shot 2021-06-07 at 9 58 21 PM" src="https://user-images.githubusercontent.com/25035900/121110599-8b135f80-c7db-11eb-8a3e-8404c175bf51.png">
