### PR TITLE
Fix/52 nav menu indicator

### DIFF
--- a/src/components/organisms/TimelineControls.js
+++ b/src/components/organisms/TimelineControls.js
@@ -1,7 +1,7 @@
 import React, {useState} from 'react'
 import PropTypes from 'prop-types'
 import Controls from '../atoms/Controls'
-import {Link} from 'react-router-dom'
+import {NavLink} from 'react-router-dom'
 
 const TimelineControls = ({changePostDirection, onChange}) => {
   const [dateDirection, setDateDirection] = useState('normal')
@@ -44,14 +44,20 @@ const TimelineControls = ({changePostDirection, onChange}) => {
     textDecoration: 'none',
   }
 
+  const navStyle = {
+    display: 'inline-block',
+  }
+
   return (
     <Controls>
-      <Link style={style} to={`/`}>
-        Timelines
-      </Link>
-      <Link style={style} to={`/add-new-post`}>
-        New Post
-      </Link>
+      <nav style={navStyle}>
+        <NavLink style={style} to={`/`} activeClassName="selected">
+          Timelines
+        </NavLink>
+        <NavLink style={style} to={`/add-new-post`} activeClassName="selected">
+          New Post
+        </NavLink>
+      </nav>
       <button style={style} onClick={sortByDate}>
         {sortDatesLabel}
       </button>

--- a/src/index.css
+++ b/src/index.css
@@ -37,6 +37,18 @@ main {
   max-width: 800px;
 }
 
+nav a {
+  transition: box-shadow 0.3s ease-in-out;
+}
+
+nav a.selected {
+  box-shadow: 0 1px 0 0;
+}
+
+nav a:hover {
+  box-shadow: 0 2px 0 0;
+}
+
 article {
   background-color: inherit;
   margin: 0 auto 2.4em auto;


### PR DESCRIPTION
Closes #52 

This PR adds navigation indication on the nav portion of the app. By utilizing the `<NavLink />` component from [React Router](https://reactrouter.com/web/api/NavLink), we can use the activeClassName prop to indicate which item is currently selected.

After Updates:
<img width="800" alt="Screen Shot 2021-06-10 at 5 37 17 PM" src="https://user-images.githubusercontent.com/25035900/121600561-a5834e00-ca12-11eb-8f6e-ee1d7adeb82a.png">

<img width="765" alt="Screen Shot 2021-06-10 at 5 37 13 PM" src="https://user-images.githubusercontent.com/25035900/121600559-a4eab780-ca12-11eb-8a78-c0f5a2a2dfe5.png">
