### PR TITLE
Feature/42 image content shift

### DIFF
--- a/src/components/organisms/AddNewPost/index.js
+++ b/src/components/organisms/AddNewPost/index.js
@@ -181,7 +181,6 @@ const AddNewPost = ({title, uid}) => {
       date,
       existingTimelineKey: selectedTimelineID,
       isNewTimeline: shouldForceNewTimeline || isNewTimeline,
-      mediaUrl: mediaItemUrl,
       media: {
         height: mediaUpload.height,
         url: mediaItemUrl,

--- a/src/components/organisms/AddNewPost/index.js
+++ b/src/components/organisms/AddNewPost/index.js
@@ -1,4 +1,3 @@
-/* eslint-disable */
 import React, {useReducer, useEffect} from 'react'
 import PropTypes from 'prop-types'
 import {Redirect} from 'react-router-dom'
@@ -135,15 +134,20 @@ const AddNewPost = ({title, uid}) => {
   }
 
   const setMediaAndPlaceholder = async e => {
-    if (e.target.files[0]) {
-      await resizeImage(e.target.files[0], resizedImage => {
-        dispatch({type: 'setMediaUpload', mediaUpload: e.target.files[0]})
-        dispatch({
-          type: 'setMediaPlaceholderUrl',
-          mediaPlaceholderUrl: URL.createObjectURL(resizedImage),
-        })
-      })
+    if (! e.target.files[0]) {
+      return;
     }
+
+    const resizedImage = await resizeImage(e.target.files[0])
+
+    dispatch({
+      type: 'setMediaUpload',
+      mediaUpload: e.target.files[0]
+    })
+    dispatch({
+      type: 'setMediaPlaceholderUrl',
+      mediaPlaceholderUrl: URL.createObjectURL(resizedImage.file),
+    })
   }
 
   const resetMedia = e => {

--- a/src/components/organisms/AddNewPost/index.js
+++ b/src/components/organisms/AddNewPost/index.js
@@ -142,7 +142,7 @@ const AddNewPost = ({title, uid}) => {
 
     dispatch({
       type: 'setMediaUpload',
-      mediaUpload: e.target.files[0]
+      mediaUpload: resizedImage,
     })
     dispatch({
       type: 'setMediaPlaceholderUrl',
@@ -174,7 +174,7 @@ const AddNewPost = ({title, uid}) => {
     let mediaItemUrl = ''
 
     if (mediaUpload) {
-      mediaItemUrl = await uploadMediaToStorage(mediaUpload, uid)
+      mediaItemUrl = await uploadMediaToStorage(mediaUpload.file, uid)
     }
 
     saveNewPost({
@@ -182,6 +182,11 @@ const AddNewPost = ({title, uid}) => {
       existingTimelineKey: selectedTimelineID,
       isNewTimeline: shouldForceNewTimeline || isNewTimeline,
       mediaUrl: mediaItemUrl,
+      media: {
+        height: mediaUpload.height,
+        url: mediaItemUrl,
+        width: mediaUpload.width,
+      },
       newTimelineName,
       title: postTitle,
       uid,

--- a/src/components/organisms/Single.js
+++ b/src/components/organisms/Single.js
@@ -4,30 +4,18 @@ import TimelinePost from '../organisms/TimelinePost'
 import PostControls from '../molecules/PostControls'
 
 const Single = props => {
-  const {date, id, imageURL, slug, timelines, title} = props
+  const {id} = props;
 
   return (
-    <div>
+    <div id={id}>
       <PostControls {...props} />
-      <TimelinePost
-        date={date}
-        id={id}
-        imageURL={imageURL}
-        slug={slug}
-        timelines={timelines}
-        title={title}
-      />
+      <TimelinePost {...props} />
     </div>
   )
 }
 
 Single.propTypes = {
-  date: PropTypes.string,
   id: PropTypes.string,
-  imageURL: PropTypes.string,
-  slug: PropTypes.string,
-  timelines: PropTypes.object,
-  title: PropTypes.string,
 }
 
 export default Single

--- a/src/components/organisms/Timeline/index.js
+++ b/src/components/organisms/Timeline/index.js
@@ -14,7 +14,7 @@ export default function Timeline({timelinePosts}) {
   }, [isLoaded, timelinePosts])
 
   const loadingStyle = {
-    opacity: hasPosts ? 1 : 0,
+    opacity: isLoaded ? 1 : 0,
     transition: 'opacity 300ms linear',
   }
 

--- a/src/components/organisms/Timeline/index.js
+++ b/src/components/organisms/Timeline/index.js
@@ -1,56 +1,32 @@
-import React, {useState, useEffect} from 'react'
+import React, {useEffect, useState} from 'react'
 import PropTypes from 'prop-types'
 import TimelinePost from '../TimelinePost'
 
-export default function Timeline({timelinePosts, uid}) {
+export default function Timeline({timelinePosts}) {
   const [isLoaded, setIsLoaded] = useState(false)
+  const hasPosts = Array.isArray(timelinePosts) && timelinePosts.length > 0
 
   // Check if posts are loaded.
   useEffect(() => {
-    if (uid !== null && Array.isArray(timelinePosts) && timelinePosts.length > 0) {
+    if (hasPosts) {
       setIsLoaded(true)
     }
-  }, [isLoaded, timelinePosts, uid])
+  }, [isLoaded, timelinePosts])
 
   const loadingStyle = {
-    opacity: isLoaded ? 1 : 0,
+    opacity: hasPosts ? 1 : 0,
     transition: 'opacity 300ms linear',
   }
 
   return (
     <div style={loadingStyle}>
-      {isLoaded === true &&
-        timelinePosts.length >= 1 &&
-        timelinePosts.map((data, key) => {
-          const {date, id, imageURL, slug, timelines, title} = data
-
-          return (
-            <TimelinePost
-              date={date}
-              id={id}
-              imageURL={imageURL}
-              key={key}
-              slug={slug}
-              style={loadingStyle}
-              timelines={timelines}
-              title={title}
-            />
-          )
-        })}
+      { hasPosts &&
+        timelinePosts.map((data) => <TimelinePost key={data.id} {...data} />)
+      }
     </div>
   )
 }
 
 Timeline.propTypes = {
-  timelinePosts: PropTypes.arrayOf(
-    PropTypes.shape({
-      date: PropTypes.string,
-      id: PropTypes.string,
-      imageURL: PropTypes.string,
-      slug: PropTypes.string,
-      timelines: PropTypes.object,
-      title: PropTypes.string,
-    }),
-  ),
-  uid: PropTypes.string,
+  timelinePosts: PropTypes.arrayOf(PropTypes.object)
 }

--- a/src/components/organisms/TimelinePost.js
+++ b/src/components/organisms/TimelinePost.js
@@ -5,8 +5,9 @@ import firebase from '../../firebase'
 import {format} from 'date-fns'
 import TimelineLinks from '../atoms/TimelineLinks'
 
-const TimelinePost = ({date, id, imageURL, timelines, title}) => {
+const TimelinePost = ({date, id, media, timelines, title}) => {
   const [timelineData, setTimelineData] = useState([])
+  const {height, url, width} = media
 
   const style = {
     padding: '.2em',
@@ -43,7 +44,7 @@ const TimelinePost = ({date, id, imageURL, timelines, title}) => {
         <TimelineLinks groupId={id} timelines={timelineData} />
         <p>{format(new Date(date), 'iiii, MMMM d, RRRR hh:mm a')}</p>
       </div>
-      {imageURL && <img src={imageURL} alt={title} />}
+      {url && <img alt={title} src={url} height={height} width={width} />}
     </article>
   )
 }
@@ -51,9 +52,17 @@ const TimelinePost = ({date, id, imageURL, timelines, title}) => {
 TimelinePost.propTypes = {
   date: PropTypes.string,
   id: PropTypes.string,
-  imageURL: PropTypes.string,
+  media: PropTypes.shape({
+    height: PropTypes.number,
+    url: PropTypes.string,
+    width: PropTypes.number,
+  }),
   timelines: PropTypes.object,
   title: PropTypes.string,
+}
+
+TimelinePost.defaultProps = {
+  media: {},
 }
 
 export default TimelinePost

--- a/src/index.css
+++ b/src/index.css
@@ -59,6 +59,7 @@ article {
 article img {
   border-radius: 0.4em;
   display: block;
+  height: auto;
   max-width: 100%;
   width: 100%;
 }

--- a/src/utilities/jimp/image-manipulation.js
+++ b/src/utilities/jimp/image-manipulation.js
@@ -16,9 +16,9 @@ const resizeImage = async (imageFile) => {
   const optimizedImageBuffer = await Jimp
     .read(URL.createObjectURL(imageFile))
     .then((image) => image
-        .scaleToFit(800, 800)      // 800x800 softcrop
-        .quality(80)               // Set JPEG quality
-    ).then((image)=>{
+        .scaleToFit(800, Jimp.AUTO) // 800xAUTO soft scale to a width of 800px.
+        .quality(85)                // Set JPEG quality
+    ).then((image) => {
       // clone paramaters from newly generated image object.
       const tempImgDataStorage = {...image.bitmap};
 

--- a/src/utilities/jimp/image-manipulation.js
+++ b/src/utilities/jimp/image-manipulation.js
@@ -15,16 +15,19 @@ const resizeImage = async (imageFile) => {
 
   const optimizedImageBuffer = await Jimp
     .read(URL.createObjectURL(imageFile))
-    .then((image) => {
-      // Assign size values.
-      resizedImageData.height = image?.bitmap?.height
-      resizedImageData.width = image?.bitmap?.height
-
-      // Return manipulated image buffer.
-      return image
+    .then((image) => image
         .scaleToFit(800, 800)      // 800x800 softcrop
         .quality(80)               // Set JPEG quality
-        .getBufferAsync(Jimp.AUTO) // Convert to buffer
+    ).then((image)=>{
+      // clone paramaters from newly generated image object.
+      const tempImgDataStorage = {...image.bitmap};
+
+      // Assign new height & width values to resized resizedImageData.
+      resizedImageData.height = tempImgDataStorage.height
+      resizedImageData.width = tempImgDataStorage.width
+
+      // Return buffer.
+      return image.getBufferAsync(Jimp.AUTO) // Convert to buffer
     }).catch((err) => {
       console.error(err);
     })

--- a/src/utilities/saveNewPost.js
+++ b/src/utilities/saveNewPost.js
@@ -15,7 +15,6 @@ export default function saveNewPost({
   existingTimelineKey,
   isNewTimeline = true,
   media = {},
-  mediaUrl,
   newTimelineName,
   title,
   uid,
@@ -63,7 +62,6 @@ export default function saveNewPost({
         date: date,
         dateCreated: new Date(),
         id: newPostKey,
-        imageURL: mediaUrl,
         media,
         slug: sanitizeHyphenatedSlug(title),
         timelines: {

--- a/src/utilities/saveNewPost.js
+++ b/src/utilities/saveNewPost.js
@@ -14,6 +14,7 @@ export default function saveNewPost({
   date,
   existingTimelineKey,
   isNewTimeline = true,
+  media = {},
   mediaUrl,
   newTimelineName,
   title,
@@ -63,6 +64,7 @@ export default function saveNewPost({
         dateCreated: new Date(),
         id: newPostKey,
         imageURL: mediaUrl,
+        media,
         slug: sanitizeHyphenatedSlug(title),
         timelines: {
           [timelineKey]: timelineKey,


### PR DESCRIPTION
Closes #42

This PR refactors `resizeImage()` and `setMediaAndPlaceholder()` areas to improve media processing.

Updates
- Simplify and refactor `resizeImage()`
- Update `setMediaAndPlaceholder()` to handle new data structure
- Change image storage structure to from `imageURL` to `media` which is an object that stores `url`, `height`, and `width`
- Image resizing to `800xAuto`
- Add image height and width attributes to `img` tags to fix scaling
- Simplify components by spreading props to `TimelinePost` components
- Simplify timeline conditionals

This example demonstrates content shift not occuring on a hard reload.
![Jun-11-2021 21-49-32](https://user-images.githubusercontent.com/25035900/121761874-8c58cb00-cb00-11eb-899a-99de7313c2cf.gif)