### PR TITLE
Modify how posts are refreshed

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -33,17 +33,22 @@ const App = () => {
     isLoggedIn()
   }, [])
 
+  // Watch posts for updates and trigger a refresh on changes.
   useEffect(() => {
-    /**
-     * If logged in, Trigger a refetch if `posts/` changes.
-     */
     if (uid) {
+      const refreshPosts = async () => {
+        // wait on function to resolve to true.
+        const allPosts = await getAllUserPosts(uid)
+        // If we have posts, set them.
+        if (Array.isArray(allPosts)) {
+          setPosts(allPosts)
+        }
+      }
+
       firebase
         .database()
         .ref('posts/')
-        .on('child_changed', () => {
-          setPosts([])
-        })
+        .on('child_changed', () => refreshPosts())
     }
 
     // Remove all event listeners on posts.


### PR DESCRIPTION
Closes #67 

This PR changes how posts are set after a refresh.

Previously posts were being set to an empty Array which triggered a new post refresh. However, this caused unwanted rendering hangups in which no posts were present when we already had posts. By triggering a refresh and then updating the current state with the new posts fetch updates feel seemless and editing a post no longer toggles off edit mode on update.

After Updates
![Jun-15-2021 19-37-14](https://user-images.githubusercontent.com/25035900/122138037-ebc21e00-ce13-11eb-9f00-dfed130e2cf8.gif)
