### PR TITLE
Refresh posts on delete

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -71,6 +71,13 @@ const App = () => {
 
           refreshPosts()
         })
+
+        firebase
+        .database()
+        .ref(`posts/${uid}`)
+        .on('child_removed', () => {
+          refreshPosts()
+        })
     }
 
     // Initalize login check.


### PR DESCRIPTION
Closes #47 

This issue resolves post refreshing when a post has been deleted. Previously, this was not working because `child_changed` only looks for changes on the child post nodes. These changes do not include the node being removed. As a result, a second event listener is required `child_moved`. See https://firebase.google.com/docs/database/web/lists-of-data